### PR TITLE
[FEAT] Share 기능 

### DIFF
--- a/Sedam/Sedam/DesignSystem/Component/Common/SinglePopUpView.swift
+++ b/Sedam/Sedam/DesignSystem/Component/Common/SinglePopUpView.swift
@@ -29,7 +29,7 @@ struct SinglePopUpView: View {
                 
                 Text(message)
                     .multilineTextAlignment(.center)
-                    .padding(12)
+                    .padding(.vertical, 12)
                     .font(.maruburiRegular14)
                 
                 Button {
@@ -38,18 +38,18 @@ struct SinglePopUpView: View {
                     Text(buttonText)
                         .font(.pretendardSemiBold14)
                         .foregroundStyle(.white)
-                        .padding(8)
+                        .padding(.vertical, 12)
+                        .frame(width: 200)
                 }
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .foregroundStyle(.juniperBerries)
                 )
-                .frame(height: 44)
                 .padding(.bottom, 12)
             }
+            .frame(width: 300)
             .background(.modernIvory)
             .roundedCorner(16, corners: .allCorners)
-            .padding(.horizontal, 20)
         }
         .ignoresSafeArea(.all)
     }

--- a/Sedam/Sedam/DesignSystem/Component/Shape/RoundedCorner.swift
+++ b/Sedam/Sedam/DesignSystem/Component/Shape/RoundedCorner.swift
@@ -18,9 +18,7 @@ struct RoundedCorner: Shape {
 }
 
 extension View {
-    
     func roundedCorner(_ radius: CGFloat, corners: UIRectCorner) -> some View {
         clipShape(RoundedCorner(radius: radius, corners: corners) )
     }
-    
 }

--- a/Sedam/Sedam/DesignSystem/View/CardView.swift
+++ b/Sedam/Sedam/DesignSystem/View/CardView.swift
@@ -1,0 +1,39 @@
+//
+//  CardView.swift
+//  Sedam
+//
+//  Created by minsong kim on 5/29/25.
+//
+
+import SwiftUI
+
+struct CardView: View {
+    var title: String
+    var content: String
+    var words: String
+    @Binding var colors: Color
+    @Binding var fontColors: Color
+    @Binding var isThreeWords: Bool
+    
+    var body: some View {
+        ZStack {
+            colors
+                .ignoresSafeArea()
+            
+            VStack(spacing: 16) {
+                if isThreeWords {
+                    Text(words)
+                        .font(.maruburiRegular10)
+                }
+                Text(title)
+                    .font(.maruburiBold18)
+                    .multilineTextAlignment(.center)
+                Text(content)
+                    .font(.maruburiRegular14)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(16)
+            }
+            .foregroundStyle(fontColors)
+        }
+    }
+}

--- a/Sedam/Sedam/Extension/View+.swift
+++ b/Sedam/Sedam/Extension/View+.swift
@@ -1,0 +1,24 @@
+//
+//  View+.swift
+//  Sedam
+//
+//  Created by minsong kim on 5/29/25.
+//
+
+import SwiftUI
+
+extension View {
+    //뷰를 동적 크기로 렌더링하고 padding만큼 여백을 붙여 UIImage로 반환
+    func renderedImage(withPadding padding: CGFloat = 20, backgroundColor: Color) -> UIImage {
+        let view = self
+            .padding(padding)
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        
+        // ImageRenderer 이용
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = UIScreen.main.scale
+        renderer.proposedSize = .unspecified
+        return renderer.uiImage!
+    }
+}

--- a/Sedam/Sedam/Info.plist
+++ b/Sedam/Sedam/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>&quot;이미지를 저장하기 위해서는 사진 라이브러리 접근 권한이 필요합니다.&quot;</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>itms-apps</string>

--- a/Sedam/Sedam/Presentation/Navigation/Router/Router.swift
+++ b/Sedam/Sedam/Presentation/Navigation/Router/Router.swift
@@ -13,6 +13,7 @@ final class Router: ObservableObject {
         case createPost
         case updatePost(id: String, title: String, content: String)
         case postDetail(postId: String)
+        case sharePost(title: String, content: String, words: String)
         case myPostList
     }
 

--- a/Sedam/Sedam/Presentation/Navigation/Router/RouterView.swift
+++ b/Sedam/Sedam/Presentation/Navigation/Router/RouterView.swift
@@ -31,6 +31,8 @@ struct RouterView<Content: View>: View {
                         PostUpdateView(title: title, content: content, postId: id)
                     case .postDetail(let id):
                         PostView(postId: id)
+                    case .sharePost(let title, let content, let words):
+                        PostShareView(title: title, content: content, words: words)
                     case .myPostList:
                         MyPostListView()
                     }

--- a/Sedam/Sedam/Presentation/Post/PostShareView.swift
+++ b/Sedam/Sedam/Presentation/Post/PostShareView.swift
@@ -1,0 +1,132 @@
+//
+//  PostShareView.swift
+//  Sedam
+//
+//  Created by minsong kim on 5/29/25.
+//
+
+import SwiftUI
+
+struct PostShareView: View {
+    var title: String
+    var content: String
+    var words: String
+    @State var isThreeWords: Bool = false
+    @State var backgroundColor: Color = .modernIvory
+    @State var fontColors: Color = .black
+    @State private var showImageSavePopup: Bool = false
+    @State private var imageSavePopUpMessage: String = ""
+    @State private var imageSaver = ImageSaver()
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Text("템플릿일 뿐, 실제 이미지에서는 여백이 다를 수 있습니다.")
+                .font(.pretendardSemiBold14)
+            CardView(
+                title: title,
+                content: content,
+                words: words,
+                colors: $backgroundColor,
+                fontColors: $fontColors,
+                isThreeWords: $isThreeWords
+            )
+            .frame(minWidth: 300, minHeight: 300)
+            .roundedCorner(16, corners: .allCorners)
+            Toggle("3단어 표시", isOn: $isThreeWords)
+                .padding(.horizontal, 120)
+                .font(.pretendardSemiBold14)
+                .toggleStyle(.switch)
+            HStack {
+                Rectangle()
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(8)
+                    .foregroundStyle(.modernIvory)
+                    .onTapGesture {
+                        backgroundColor = .modernIvory
+                        fontColors = .black
+                    }
+                Rectangle()
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(8)
+                    .foregroundStyle(.tranquility)
+                    .onTapGesture {
+                        backgroundColor = .tranquility
+                        fontColors = .black
+                    }
+                Rectangle()
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(8)
+                    .foregroundStyle(.juniperBerries)
+                    .onTapGesture {
+                        backgroundColor = .juniperBerries
+                        fontColors = .white
+                    }
+                Rectangle()
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(8)
+                    .foregroundStyle(.dadsCoupe)
+                    .onTapGesture {
+                        backgroundColor = .dadsCoupe
+                        fontColors = .white
+                    }
+            }
+            Spacer()
+            MainButton(title: "텍스트만 공유하기", font: .pretendardSemiBold14, color: .juniperBerries)
+                .tap {
+                    let shareText = [title, content]
+                        .joined(separator: "\n\n")
+                    let activityVC = UIActivityViewController(
+                        activityItems: [shareText],
+                        applicationActivities: nil
+                    )
+                    if let root = UIApplication.shared.windows.first?.rootViewController {
+                        root.present(activityVC, animated: true)
+                    }
+                }
+                .padding(.horizontal, 16)
+            MainButton(title: "이미지 공유하기", font: .pretendardSemiBold14, color: .dadsCoupe)
+                .tap {
+                    let image = CardView (
+                        title: title,
+                        content: content,
+                        words: words,
+                        colors: $backgroundColor,
+                        fontColors: $fontColors,
+                        isThreeWords: $isThreeWords
+                    ).renderedImage(withPadding: 50, backgroundColor: backgroundColor)
+                    
+                    imageSaver.writeToPhotoLibrary(image) { result in
+                        DispatchQueue.main.async {
+                            switch result {
+                            case .success:
+                                imageSavePopUpMessage = "이미지 저장에 성공하였습니다!"
+                            case .failure(_):
+                                imageSavePopUpMessage = "이미지 저장에 실패했습니다.\n\n다시 시도해주세요."
+                            }
+                            withAnimation {
+                                showImageSavePopup = true
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            
+        }
+        .overlay {
+            if showImageSavePopup {
+                SinglePopUpView(
+                    showPopUp: $showImageSavePopup,
+                    title: "이미지 저장",
+                    message: imageSavePopUpMessage,
+                    buttonText: "확인",
+                    buttonAction: {
+                        withAnimation {
+                            showImageSavePopup = false
+                        }
+                    }
+                )
+            }
+        }
+    }
+}

--- a/Sedam/Sedam/Presentation/Post/PostShareView.swift
+++ b/Sedam/Sedam/Presentation/Post/PostShareView.swift
@@ -31,8 +31,8 @@ struct PostShareView: View {
                 fontColors: $fontColors,
                 isThreeWords: $isThreeWords
             )
-            .frame(minWidth: 300, minHeight: 300)
             .roundedCorner(16, corners: .allCorners)
+            .padding(12)
             Toggle("3단어 표시", isOn: $isThreeWords)
                 .padding(.horizontal, 120)
                 .font(.pretendardSemiBold14)
@@ -85,7 +85,7 @@ struct PostShareView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-            MainButton(title: "이미지 공유하기", font: .pretendardSemiBold14, color: .dadsCoupe)
+            MainButton(title: "이미지 저장하기", font: .pretendardSemiBold14, color: .dadsCoupe)
                 .tap {
                     let image = CardView (
                         title: title,

--- a/Sedam/Sedam/Presentation/Post/PostView.swift
+++ b/Sedam/Sedam/Presentation/Post/PostView.swift
@@ -51,6 +51,17 @@ struct PostView: View {
                                 .frame(width: 15)
                                 .foregroundStyle(.black)
                         }
+                        
+                        Button {
+                            print("share post")
+                            router.push(.sharePost(title: post?.title ?? "", content: post?.content ?? "", words: post?.todayWords.joined(separator: ", ") ?? ""))
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 15)
+                                .foregroundStyle(.black)
+                        }
                     }
                 }
                 Spacer()

--- a/Sedam/Sedam/Presentation/Post/PostViewModel.swift
+++ b/Sedam/Sedam/Presentation/Post/PostViewModel.swift
@@ -80,7 +80,7 @@ class PostViewModel: ObservableObject {
         Task {
             do {
                 _ = try await postService.updateOnePost(id: id, title: title, content: content)
-//                return publisher.map(true)
+                //                return publisher.map(true)
                 //TODO: 성공시 성공했다고 반환, router.pop() 필요 (진동과 함께)
                 postUpdateSubject.send()
             } catch NetworkError.accessDenied {

--- a/Sedam/Sedam/Util/ImageSaver.swift
+++ b/Sedam/Sedam/Util/ImageSaver.swift
@@ -1,0 +1,36 @@
+//
+//  ImageSaver.swift
+//  Sedam
+//
+//  Created by minsong kim on 5/30/25.
+//
+
+import UIKit
+
+// UIImage를 포토 라이브러리에 저장하고, 완료를 콜백으로 알려줍니다.
+final class ImageSaver: NSObject {
+    private var onComplete: ((Result<Void, Error>) -> Void)?
+
+    // 저장 시작
+    func writeToPhotoLibrary(_ image: UIImage,
+                             completion: ((Result<Void, Error>) -> Void)? = nil) {
+        self.onComplete = completion
+        UIImageWriteToSavedPhotosAlbum(
+            image,
+            self,
+            #selector(saveCompleted(_:didFinishSavingWithError:contextInfo:)),
+            nil
+        )
+    }
+
+    // 저장 완료 핸들러
+    @objc private func saveCompleted(_ image: UIImage,
+                                     didFinishSavingWithError error: Error?,
+                                     contextInfo: UnsafeRawPointer) {
+        if let error = error {
+            onComplete?(.failure(error))
+        } else {
+            onComplete?(.success(()))
+        }
+    }
+}


### PR DESCRIPTION
## 📚 작업 설명
- 이미지 저장 기능
- 텍스트 공유 기능

## 🔥 트러블 슈팅
### 1. 콜백이 호출되지 않음: ImageSaver 인스턴스 해제 문제
“이미지 저장하기” 버튼 탭 후에도 팝업(showImageSavePopup)이 보이지 않았다. ImageSaver()를 로컬 상수로 생성하면 함수 종료 시 즉시 해제되어, 내부 UIImageWriteToSavedPhotosAlbum 콜백이 호출되지 않아 생기는 문제로, 뷰의 생명주기에 맞춰 @State private var imageSaver = ImageSaver()로 인스턴스를 보관하는 방법으로 해결하였다.
```swift
struct PostShareView: View {
    @State private var imageSaver = ImageSaver()
    // …
}
```

### 2. View를 Image로 변환할 때, 동적으로 크기 랜더링
| 텍스트 부분만 잘려서 저장되는 이미지 | 
|:--------:|
|<img src="https://github.com/user-attachments/assets/9085c0d2-2bb0-44c8-a8c8-79802395d06a" alt="sedam image" width="400">|

기존 snapshot() 코드로는 CardView에 지정한 프레임이 아니라, 텍스트 부분만 잘려서 저장되는 문제가 있었다. snapshot() 이 뷰의 intrinsic content size만 반영하고, 외부 .frame은 무시해서 생긴 일이었다. 
```swift
extension View {
    func snapshot() -> UIImage {
        let controller = UIHostingController(rootView: self.edgesIgnoringSafeArea(.all))
        let view = controller.view
      
        let targetSize = controller.view.intrinsicContentSize

        view?.bounds = CGRect(origin: .zero, size: targetSize)
        view?.backgroundColor = .clear

        let renderer = UIGraphicsImageRenderer(size: targetSize)

        return renderer.image { _ in 
             view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
        }
    }
}
```
때문에 다른 방법을 사용해야 했는데, iOS 16+ 이기에 ImageRenderer를 사용하였다. 이때 여백을 검은색이 아닌 같은 배경색으로 주고, cornerRadius 역시 적용해 주었다. 또한 제목/ 본문 길이에 따라 유연한 크기와 padding을 주고 싶었는데 이는 renderer.proposedSize = .unspecified로 설정하면, SwiftUI가 뷰의 intrinsic size에 따라 최적 크기를 결정하고 padding으로 여백을 유지할 수도 있었다.
| 여백과 corner Radius, 배경색이 들어가고 길이에 따라 달라진 이미지 | 
|:--------:|
|<img src="https://github.com/user-attachments/assets/7604d2ef-db20-458c-94ac-881688943298" alt="sedam image" width="400">|

```swift
extension View {
    //뷰를 동적 크기로 렌더링하고 padding만큼 여백을 붙여 UIImage로 반환
    func renderedImage(withPadding padding: CGFloat = 20, backgroundColor: Color) -> UIImage {
        let view = self
            .padding(padding)
            .background(backgroundColor)
            .clipShape(RoundedRectangle(cornerRadius: 12))
        
        // ImageRenderer 이용
        let renderer = ImageRenderer(content: view)
        renderer.scale = UIScreen.main.scale
        renderer.proposedSize = .unspecified
        return renderer.uiImage!
    }
}
```